### PR TITLE
🧪 Add simulation sections (Atomic Red Team) to 34 registry_set rules

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -179,3 +179,12 @@ falsepositives:
     - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
     - Legitimate administrator sets up autorun keys for legitimate reason
 level: medium
+simulation:
+    - type: atomic-red-team
+      name: Reg Key Run
+      technique: T1547.001
+      atomic_guid: e55be3fd-3521-4610-9d1a-e210e42dcf05
+    - type: atomic-red-team
+      name: Reg Key RunOnce
+      technique: T1547.001
+      atomic_guid: 554cbd88-cde1-4b56-8168-0be552eed9eb

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_session_manager.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_session_manager.yml
@@ -38,3 +38,8 @@ falsepositives:
     - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
     - Legitimate administrator sets up autorun keys for legitimate reason
 level: medium
+simulation:
+    - type: atomic-red-team
+      name: Modify BootExecute Value
+      technique: T1547.001
+      atomic_guid: befc2b40-d487-4a5a-8813-c11085fb5672

--- a/rules/windows/registry/registry_set/registry_set_chrome_extension.yml
+++ b/rules/windows/registry/registry_set/registry_set_chrome_extension.yml
@@ -130,3 +130,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Running Chrome VPN Extensions via the Registry 2 vpn extension
+    technique: T1133
+    atomic_guid: 4c8db261-a58b-42a6-a866-0a294deedde4

--- a/rules/windows/registry/registry_set/registry_set_disable_function_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_function_user.yml
@@ -48,3 +48,32 @@ detection:
 falsepositives:
     - Legitimate admin script
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Disable Windows Registry Tool
+    technique: T1112
+    atomic_guid: ac34b0f7-0f85-4ac0-b93e-3ced2bc69bb8
+  - type: atomic-red-team
+    name: Disable Windows CMD application
+    technique: T1112
+    atomic_guid: d2561a6d-72bd-408c-b150-13efe1801c2a
+  - type: atomic-red-team
+    name: Disable Windows Task Manager application
+    technique: T1112
+    atomic_guid: af254e70-dd0e-4de6-9afe-a994d9ea8b62
+  - type: atomic-red-team
+    name: Disable Windows Notification Center
+    technique: T1112
+    atomic_guid: c0d6d67f-1f63-42cc-95c0-5fd6b20082ad
+  - type: atomic-red-team
+    name: Disable Windows Lock Workstation Feature
+    technique: T1112
+    atomic_guid: 3dacb0d2-46ee-4c27-ac1b-f9886bf91a56
+  - type: atomic-red-team
+    name: Disable Windows Change Password Feature
+    technique: T1112
+    atomic_guid: d4a6da40-618f-454d-9a9e-26af552aaeb0
+  - type: atomic-red-team
+    name: Disable Windows Shutdown Button
+    technique: T1112
+    atomic_guid: 6e0d1131-2d7e-4905-8ca5-d6172f05d03d

--- a/rules/windows/registry/registry_set/registry_set_disable_privacy_settings_experience.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_privacy_settings_experience.yml
@@ -21,3 +21,12 @@ detection:
 falsepositives:
     - Legitimate admin script
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: LockBit Black - Disable Privacy Settings Experience Using Registry -cmd
+    technique: T1685
+    atomic_guid: d6d22332-d07d-498f-aea0-6139ecb7850e
+  - type: atomic-red-team
+    name: LockBit Black - Disable Privacy Settings Experience Using Registry -Powershell
+    technique: T1685
+    atomic_guid: d8c57eaa-497a-4a08-961e-bd5efd7c9374

--- a/rules/windows/registry/registry_set/registry_set_disable_windows_event_log_access.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_windows_event_log_access.yml
@@ -48,3 +48,16 @@ detection:
 falsepositives:
     - Administrative activity, still unlikely
 level: high
+simulation:
+    - type: atomic-red-team
+      name: Modify Event Log Access Permissions via Registry - PowerShell
+      technique: T1562.002
+      atomic_guid: a0cb81f8-44d0-4ac4-a8f3-c5c7f43a12c1
+    - type: atomic-red-team
+      name: Modify Event Log Channel Access Permissions via Registry - PowerShell
+      technique: T1562.002
+      atomic_guid: 8e81d090-0cd6-4d46-863c-eec11311298f
+    - type: atomic-red-team
+      name: Modify Event Log Channel Access Permissions via Registry 2 - PowerShell
+      technique: T1562.002
+      atomic_guid: 85e6eff8-3ed4-4e03-ae50-aa6a404898a5

--- a/rules/windows/registry/registry_set/registry_set_disable_windows_firewall.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_windows_firewall.yml
@@ -23,3 +23,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: LockBit Black - Unusual Windows firewall registry modification -cmd
+    technique: T1686
+    atomic_guid: a4651931-ebbb-4cde-9363-ddf3d66214cb

--- a/rules/windows/registry/registry_set/registry_set_disallowrun_execution.yml
+++ b/rules/windows/registry/registry_set/registry_set_disallowrun_execution.yml
@@ -22,3 +22,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: DisallowRun Execution Of Certain Applications
+    technique: T1112
+    atomic_guid: 71db768a-5a9c-4047-b5e7-59e01f188e84

--- a/rules/windows/registry/registry_set/registry_set_hidden_extention.yml
+++ b/rules/windows/registry/registry_set/registry_set_hidden_extention.yml
@@ -26,3 +26,8 @@ detection:
 falsepositives:
     - Administrative scripts
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Modify Registry of Current User Profile - cmd
+    technique: T1112
+    atomic_guid: 1324796b-d0f6-455a-b4ae-21ffee6aa6b9

--- a/rules/windows/registry/registry_set/registry_set_hide_file.yml
+++ b/rules/windows/registry/registry_set/registry_set_hide_file.yml
@@ -25,3 +25,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Hide Files Through Registry
+    technique: T1564.001
+    atomic_guid: f650456b-bd49-4bc1-ae9d-271b5b9581e7

--- a/rules/windows/registry/registry_set/registry_set_hide_function_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_hide_function_user.yml
@@ -32,3 +32,28 @@ detection:
 falsepositives:
     - Legitimate admin script
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Hide Windows Clock Group Policy Feature
+    technique: T1112
+    atomic_guid: 8023db1e-ad06-4966-934b-b6a0ae52689e
+  - type: atomic-red-team
+    name: Windows HideSCAHealth Group Policy Feature
+    technique: T1112
+    atomic_guid: a4637291-40b1-4a96-8c82-b28f1d73e54e
+  - type: atomic-red-team
+    name: Windows HideSCANetwork Group Policy Feature
+    technique: T1112
+    atomic_guid: 3e757ce7-eca0-411a-9583-1c33b8508d52
+  - type: atomic-red-team
+    name: Windows HideSCAPower Group Policy Feature
+    technique: T1112
+    atomic_guid: 8d85a5d8-702f-436f-bc78-fcd9119496fc
+  - type: atomic-red-team
+    name: Windows HideSCAVolume Group Policy Feature
+    technique: T1112
+    atomic_guid: 7f037590-b4c6-4f13-b3cc-e424c5ab8ade
+  - type: atomic-red-team
+    name: Windows Modify Show Compress Color And Info Tip Registry
+    technique: T1112
+    atomic_guid: 795d3248-0394-4d4d-8e86-4e8df2a2693f

--- a/rules/windows/registry/registry_set/registry_set_install_root_or_ca_certificat.yml
+++ b/rules/windows/registry/registry_set/registry_set_install_root_or_ca_certificat.yml
@@ -32,3 +32,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Add Root Certificate to CurrentUser Certificate Store
+    technique: T1553.004
+    atomic_guid: ca20a3f1-42b5-4e21-ad3f-1049199ec2e0

--- a/rules/windows/registry/registry_set/registry_set_legalnotice_susp_message.yml
+++ b/rules/windows/registry/registry_set/registry_set_legalnotice_susp_message.yml
@@ -26,3 +26,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Configure LegalNoticeCaption and LegalNoticeText registry keys to display ransom message
+    technique: T1491.001
+    atomic_guid: ffcbfaab-c9ff-470b-928c-f086b326089b

--- a/rules/windows/registry/registry_set/registry_set_lsa_disablerestrictedadmin.yml
+++ b/rules/windows/registry/registry_set/registry_set_lsa_disablerestrictedadmin.yml
@@ -28,3 +28,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Enabling Restricted Admin Mode via Command_Prompt
+    technique: T1112
+    atomic_guid: fe7974e5-5813-477b-a7bd-311d4f535e83

--- a/rules/windows/registry/registry_set/registry_set_office_disable_protected_view_features.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_disable_protected_view_features.yml
@@ -40,3 +40,8 @@ detection:
 falsepositives:
     - Unlikely
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Disable Microsoft Office Security Features
+    technique: T1685
+    atomic_guid: 6f5fb61b-4e56-4a3d-a8c3-82e13686c6d7

--- a/rules/windows/registry/registry_set/registry_set_office_outlook_security_settings.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_outlook_security_settings.yml
@@ -31,3 +31,8 @@ detection:
 falsepositives:
     - Administrative activity
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Office Application Startup - Outlook as a C2
+    technique: T1137
+    atomic_guid: bfe6ac15-c50b-4c4f-a186-0fc6b8ba936c

--- a/rules/windows/registry/registry_set/registry_set_persistence_event_viewer_events_asp.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_event_viewer_events_asp.yml
@@ -40,3 +40,12 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Event Viewer Registry Modification - Redirection URL
+    technique: T1112
+    atomic_guid: 6174be7f-5153-4afd-92c5-e0c3b7cdb5ae
+  - type: atomic-red-team
+    name: Event Viewer Registry Modification - Redirection Program
+    technique: T1112
+    atomic_guid: 81483501-b8a5-4225-8b32-52128e2f69db

--- a/rules/windows/registry/registry_set/registry_set_persistence_ie.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_ie.yml
@@ -41,3 +41,12 @@ detection:
 falsepositives:
     - Unknown
 level: low
+simulation:
+  - type: atomic-red-team
+    name: Add domain to Trusted sites Zone
+    technique: T1112
+    atomic_guid: cf447677-5a4e-4937-a82c-e47d254afd57
+  - type: atomic-red-team
+    name: Javascript in registry
+    technique: T1112
+    atomic_guid: 15f44ea9-4571-4837-be9e-802431a7bfae

--- a/rules/windows/registry/registry_set/registry_set_persistence_outlook_homepage.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_outlook_homepage.yml
@@ -31,3 +31,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Install Outlook Home Page Persistence
+    technique: T1137.004
+    atomic_guid: 7a91ad51-e6d2-4d43-9471-f26362f5738e

--- a/rules/windows/registry/registry_set/registry_set_persistence_scrobj_dll.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_scrobj_dll.yml
@@ -22,3 +22,8 @@ detection:
 falsepositives:
     - Legitimate use of the dll.
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: COM Hijacking - InprocServer32
+    technique: T1546.015
+    atomic_guid: 48117158-d7be-441b-bc6a-d9e36e47b52b

--- a/rules/windows/registry/registry_set/registry_set_persistence_shim_database.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_shim_database.yml
@@ -33,3 +33,8 @@ detection:
 falsepositives:
     - Legitimate custom SHIM installations will also trigger this rule
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Registry key creation and/or modification events for SDB
+    technique: T1546.011
+    atomic_guid: 9b6a06f9-ab5e-4e8d-8289-1df4289db02f

--- a/rules/windows/registry/registry_set/registry_set_persistence_xll.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_xll.yml
@@ -24,3 +24,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Persistent Code Execution Via Excel Add-in File (XLL)
+    technique: T1137.006
+    atomic_guid: 9c307886-9fef-41d5-b344-073a0f5b2f5f

--- a/rules/windows/registry/registry_set/registry_set_powershell_in_run_keys.yml
+++ b/rules/windows/registry/registry_set/registry_set_powershell_in_run_keys.yml
@@ -49,3 +49,20 @@ detection:
 falsepositives:
     - Legitimate admin or third party scripts. Baseline according to your environment
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: SystemBC Malware-as-a-Service Registry
+    technique: T1547.001
+    atomic_guid: 9dc7767b-30c1-4cc4-b999-50cab5e27891
+  - type: atomic-red-team
+    name: HKCU - Policy Settings Explorer Run Key
+    technique: T1547.001
+    atomic_guid: a70faea1-e206-4f6f-8d9a-67379be8f6f1
+  - type: atomic-red-team
+    name: HKLM - Policy Settings Explorer Run Key
+    technique: T1547.001
+    atomic_guid: b5c9a9bc-dda3-4ea0-b16a-add8e81ab75f
+  - type: atomic-red-team
+    name: PowerShell Registry RunOnce
+    technique: T1547.001
+    atomic_guid: eb44f842-0457-4ddc-9b92-c4caa144ac42

--- a/rules/windows/registry/registry_set/registry_set_servicedll_hijack.yml
+++ b/rules/windows/registry/registry_set/registry_set_servicedll_hijack.yml
@@ -40,3 +40,8 @@ falsepositives:
     - Administrative scripts
     - Installation of a service
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: TinyTurla backdoor service w64time
+    technique: T1543.003
+    atomic_guid: ef0581fd-528e-4662-87bc-4c2affb86940

--- a/rules/windows/registry/registry_set/registry_set_set_nopolicies_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_set_nopolicies_user.yml
@@ -32,3 +32,44 @@ detection:
 falsepositives:
     - Legitimate admin script
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Activate Windows NoDesktop Group Policy Feature
+    technique: T1112
+    atomic_guid: 93386d41-525c-4a1b-8235-134a628dee17
+  - type: atomic-red-team
+    name: Activate Windows NoRun Group Policy Feature
+    technique: T1112
+    atomic_guid: d49ff3cc-8168-4123-b5b3-f057d9abbd55
+  - type: atomic-red-team
+    name: Activate Windows NoFind Group Policy Feature
+    technique: T1112
+    atomic_guid: ffbb407e-7f1d-4c95-b22e-548169db1fbd
+  - type: atomic-red-team
+    name: Activate Windows NoControlPanel Group Policy Feature
+    technique: T1112
+    atomic_guid: a450e469-ba54-4de1-9deb-9023a6111690
+  - type: atomic-red-team
+    name: Activate Windows NoFileMenu Group Policy Feature
+    technique: T1112
+    atomic_guid: 5e27bdb4-7fd9-455d-a2b5-4b4b22c9dea4
+  - type: atomic-red-team
+    name: Activate Windows NoClose Group Policy Feature
+    technique: T1112
+    atomic_guid: 12f50e15-dbc6-478b-a801-a746e8ba1723
+  - type: atomic-red-team
+    name: Activate Windows NoSetTaskbar Group Policy Feature
+    technique: T1112
+    atomic_guid: d29b7faf-7355-4036-9ed3-719bd17951ed
+  - type: atomic-red-team
+    name: Activate Windows NoPropertiesMyDocuments Group Policy Feature
+    technique: T1112
+    atomic_guid: 20fc9daa-bd48-4325-9aff-81b967a84b1d
+  - type: atomic-red-team
+    name: Activate Windows NoTrayContextMenu Group Policy Feature
+    technique: T1112
+    atomic_guid: 4d72d4b1-fa7b-4374-b423-0fe326da49d2
+  - type: atomic-red-team
+    name: Activate Windows NoLogOff Group Policy Feature
+    technique: T1112
+    atomic_guid: c375558d-7c25-45e9-bd64-7b23a97c1db0

--- a/rules/windows/registry/registry_set/registry_set_suppress_defender_notifications.yml
+++ b/rules/windows/registry/registry_set/registry_set_suppress_defender_notifications.yml
@@ -22,3 +22,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Suppress Win Defender Notifications
+    technique: T1112
+    atomic_guid: c30dada3-7777-4590-b970-dc890b8cf113

--- a/rules/windows/registry/registry_set/registry_set_terminal_server_tampering.yml
+++ b/rules/windows/registry/registry_set/registry_set_terminal_server_tampering.yml
@@ -83,3 +83,12 @@ detection:
 falsepositives:
     - Some of the keys mentioned here could be modified by an administrator while setting group policy (it should be investigated either way)
 level: high
+simulation:
+    - type: atomic-red-team
+      name: Disable Remote Desktop Anti-Alias Setting Through Registry
+      technique: T1112
+      atomic_guid: 61d35188-f113-4334-8245-8c6556d43909
+    - type: atomic-red-team
+      name: Disable Remote Desktop Security Settings Through Registry
+      technique: T1112
+      atomic_guid: 4b81bcfa-fb0a-45e9-90c2-e3efe5160140

--- a/rules/windows/registry/registry_set/registry_set_timeproviders_dllname.yml
+++ b/rules/windows/registry/registry_set/registry_set_timeproviders_dllname.yml
@@ -30,3 +30,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Create a new time provider
+    technique: T1547.003
+    atomic_guid: df1efab7-bc6d-4b88-8be9-91f55ae017aa

--- a/rules/windows/registry/registry_set/registry_set_treatas_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_treatas_persistence.yml
@@ -39,3 +39,8 @@ detection:
 falsepositives:
     - Legitimate use
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: COM hijacking via TreatAs
+    technique: T1546.015
+    atomic_guid: 33eacead-f117-4863-8eb0-5c6304fbfaa9

--- a/rules/windows/registry/registry_set/registry_set_uac_disable.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_disable.yml
@@ -27,3 +27,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+    - type: atomic-red-team
+      name: Disable UAC using reg.exe
+      technique: T1548.002
+      atomic_guid: 9e8af564-53ec-407e-aaa8-3cb20c3af7f9

--- a/rules/windows/registry/registry_set/registry_set_uac_disable_notification.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_disable_notification.yml
@@ -29,3 +29,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+  - type: atomic-red-team
+    name: Disable UAC notification via registry keys
+    technique: T1548.002
+    atomic_guid: 160a7c77-b00e-4111-9e45-7c2a44eda3fd

--- a/rules/windows/registry/registry_set/registry_set_uac_disable_secure_desktop_prompt.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_disable_secure_desktop_prompt.yml
@@ -28,3 +28,8 @@ detection:
 falsepositives:
     - Unknown
 level: medium
+simulation:
+    - type: atomic-red-team
+      name: Disable UAC - Switch to the secure desktop when prompting for elevation via registry key
+      technique: T1548.002
+      atomic_guid: 85f3a526-4cfa-4fe7-98c1-dea99be025c7

--- a/rules/windows/registry/registry_set/registry_set_wdigest_enable_uselogoncredential.yml
+++ b/rules/windows/registry/registry_set/registry_set_wdigest_enable_uselogoncredential.yml
@@ -24,3 +24,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Modify registry to store logon credentials
+    technique: T1112
+    atomic_guid: 3e757ce7-eca0-411a-9583-1c33b8508d52

--- a/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
+++ b/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
@@ -24,3 +24,8 @@ detection:
 falsepositives:
     - Unknown
 level: high
+simulation:
+  - type: atomic-red-team
+    name: Winlogon Notify Key Logon Persistence - PowerShell
+    technique: T1547.004
+    atomic_guid: d40da266-e073-4e5a-bb8b-2b385023e5f9


### PR DESCRIPTION
### Summary of the Pull Request

Add simulation sections referencing Atomic Red Team tests to 34 `registry_set` rules that have `atomic-red-team` references in their metadata but were missing the `simulation` field. Each simulation entry maps the rule to the corresponding ART test by matching detection criteria (registry paths, commands) against the test definition.

### Changelog

update: registry_set_asep_reg_keys_modification_currentversion - add Atomic Red Team simulation (T1547.001)
update: registry_set_asep_reg_keys_modification_session_manager - add Atomic Red Team simulation (T1547.001)
update: registry_set_chrome_extension - add Atomic Red Team simulation (T1133)
update: registry_set_disable_function_user - add Atomic Red Team simulation (T1112)
update: registry_set_disable_privacy_settings_experience - add Atomic Red Team simulation (T1685)
update: registry_set_disable_windows_event_log_access - add Atomic Red Team simulation (T1562.002)
update: registry_set_disable_windows_firewall - add Atomic Red Team simulation (T1686)
update: registry_set_disallowrun_execution - add Atomic Red Team simulation (T1112)
update: registry_set_hidden_extention - add Atomic Red Team simulation (T1112)
update: registry_set_hide_file - add Atomic Red Team simulation (T1564.001)
update: registry_set_hide_function_user - add Atomic Red Team simulation (T1112)
update: registry_set_install_root_or_ca_certificat - add Atomic Red Team simulation (T1553.004)
update: registry_set_legalnotice_susp_message - add Atomic Red Team simulation (T1491.001)
update: registry_set_lsa_disablerestrictedadmin - add Atomic Red Team simulation (T1112)
update: registry_set_office_disable_protected_view_features - add Atomic Red Team simulation (T1685)
update: registry_set_office_outlook_security_settings - add Atomic Red Team simulation (T1137)
update: registry_set_persistence_event_viewer_events_asp - add Atomic Red Team simulation (T1112)
update: registry_set_persistence_ie - add Atomic Red Team simulation (T1112)
update: registry_set_persistence_outlook_homepage - add Atomic Red Team simulation (T1137.004)
update: registry_set_persistence_scrobj_dll - add Atomic Red Team simulation (T1546.015)
update: registry_set_persistence_shim_database - add Atomic Red Team simulation (T1546.011)
update: registry_set_persistence_xll - add Atomic Red Team simulation (T1137.006)
update: registry_set_powershell_in_run_keys - add Atomic Red Team simulation (T1547.001)
update: registry_set_servicedll_hijack - add Atomic Red Team simulation (T1543.003)
update: registry_set_set_nopolicies_user - add Atomic Red Team simulation (T1112)
update: registry_set_suppress_defender_notifications - add Atomic Red Team simulation (T1112)
update: registry_set_terminal_server_tampering - add Atomic Red Team simulation (T1112)
update: registry_set_timeproviders_dllname - add Atomic Red Team simulation (T1547.003)
update: registry_set_treatas_persistence - add Atomic Red Team simulation (T1546.015)
update: registry_set_uac_disable - add Atomic Red Team simulation (T1548.002)
update: registry_set_uac_disable_notification - add Atomic Red Team simulation (T1548.002)
update: registry_set_uac_disable_secure_desktop_prompt - add Atomic Red Team simulation (T1548.002)
update: registry_set_wdigest_enable_uselogoncredential - add Atomic Red Team simulation (T1112)
update: registry_set_winlogon_notify_key - add Atomic Red Team simulation (T1547.004)

### Example Log Event

N/A - simulation sections do not affect detection logic.

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

These are updates to existing rules (not new rules), so the conventions link does not apply.